### PR TITLE
Discount edit

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -1,12 +1,12 @@
 class BulkDiscountsController < ApplicationController
-  before_action :find_merchant, only: [:index, :new, :destroy]
+  before_action :find_merchant, except: [:update, :create]
+  before_action :find_discount, only: [:show, :edit, :update, :destroy]
 
   def index
     @discounts = @merchant.bulk_discounts
   end
 
   def new
-
   end
 
   def create
@@ -21,18 +21,34 @@ class BulkDiscountsController < ApplicationController
   end
 
   def show
-    @discount = BulkDiscount.find_by(discount_params)
+  end
+
+  def edit
+  end
+  
+  def update
+    if @discount.update(discount_params)
+      redirect_to merchant_bulk_discounts_path(discount_params)
+    else
+      redirect_to edit_merchant_bulk_discount_path(discount_params)
+      flash[:alert] = "Please fill in all fields" if params[:percentage].empty? || params[:quantity].empty?
+      flash[:alert] = "Percent off must be less than 100" if params[:percentage].to_i > 99
+    end
   end
 
   def destroy
-    discount = BulkDiscount.find_by(discount_params)
-    discount.destroy
+    @discount.destroy
     redirect_to merchant_bulk_discounts_path(@merchant)
+    flash[:alert] = "Promotion ##{@discount.id} Successfully Deleted"
   end
 
   private
   def discount_params
     params.permit(:percentage, :quantity, :merchant_id, :id)
+  end
+
+  def find_discount
+    @discount = BulkDiscount.find(params[:id])
   end
 
   def find_merchant

--- a/app/views/bulk_discounts/_form.html.erb
+++ b/app/views/bulk_discounts/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: model, method: method, url: url, local: true do |f| %>
   <%= f.label "Percent off:" %>
-  <%= f.number_field :percentage, max: 99 %><br/><br/>
+  <%= f.number_field :percentage, max: 99, value: perc_value %><br/><br/>
   <%= f.label "Quantity threshold:" %>
-  <%= f.number_field :quantity %><br/><br/>
+  <%= f.number_field :quantity, value: quan_value %><br/><br/>
   <%= f.submit 'Submit'%>
 <% end %>

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,10 @@
+<%= render partial: "shared/nav" %>
+
+<h1>Edit Promotion #<%= @discount.id %></h1>
+<%= render partial: "form", locals: { 
+  method: :patch, 
+  url: merchant_bulk_discount_path(@merchant, @discount), 
+  model: @bulk_discount,
+  perc_value: @discount.percentage,
+  quan_value: @discount.quantity
+  }%>

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -5,6 +5,7 @@
   <div id="discount-<%= discount.id %>">
     <p><%= link_to "Promotion ##{discount.id}", merchant_bulk_discount_path(@merchant, discount) %></p>
     <p><%= discount.percentage %>% off bulk purchases of <%= discount.quantity %> or more items</p>
+    <p><%= link_to "Edit Promotion ##{discount.id}", edit_merchant_bulk_discount_path(@merchant, discount) %>
     <p><%= link_to "Delete Promotion ##{discount.id}", merchant_bulk_discount_path(@merchant, discount), method: :delete %>
     <br>
   </div>

--- a/app/views/bulk_discounts/new.html.erb
+++ b/app/views/bulk_discounts/new.html.erb
@@ -2,4 +2,10 @@
 
 <h1>Create a New Bulk Discount Promotion</h1>
 
-<%= render partial: "form", locals: { method: :post, url: merchant_bulk_discounts_path(@merchant), model: @bulk_discount}%>
+<%= render partial: "form", locals: { 
+  method: :post, 
+  url: merchant_bulk_discounts_path(@merchant), 
+  model: @bulk_discount,
+  perc_value: "",
+  quan_value: ""
+  }%>

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: "shared/nav" %>
+
 <h1>Promotion #<%= @discount.id %></h1>
 
 <p><%= @discount.percentage %>% off a bulk purchase of <%= @discount.quantity %> or more items</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy]
+    resources :bulk_discounts
   end
 
   namespace :admin do

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe "bulk discounts edit page" do
+  before do
+    @merchant1 = Merchant.create!(name: "Hair Care")
+
+    @discount1 = BulkDiscount.create!(percentage: 20, quantity: 10, merchant: @merchant1)
+  end
+
+  # User story 5
+  it "has a form to edit a discount, prepopulated with info" do
+    visit edit_merchant_bulk_discount_path(@merchant1, @discount1)
+
+    expect(page).to have_content("Edit Promotion ##{@discount1.id}")
+    expect(page).to have_content("Percent off:")
+    expect(page).to have_field(:percentage, with: 20)
+    expect(page).to have_content("Quantity threshold:")
+    expect(page).to have_field(:quantity, with: 10)
+    expect(page).to have_button("Submit")
+  end
+
+  it "can update an existing discount" do
+    visit merchant_bulk_discounts_path(@merchant1)
+
+    within("#discount-#{@discount1.id}") do
+      expect(page).to have_content("20% off bulk purchases of 10 or more items")
+      click_link("Edit Promotion ##{@discount1.id}")
+    end
+    
+    fill_in(:percentage, with: 30)
+    fill_in(:quantity, with: 20)
+    click_button("Submit")
+    
+    expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
+
+    within("#discount-#{@discount1.id}") do
+      expect(page).to have_content("30% off bulk purchases of 20 or more items")
+      expect(page).to_not have_content("20% off bulk purchases of 10 or more items")
+    end
+  end
+
+  it "throws an error if fields left blank" do
+    visit edit_merchant_bulk_discount_path(@merchant1, @discount1)
+
+    fill_in(:percentage, with: "")
+    click_button("Submit")
+    expect(current_path).to eq(edit_merchant_bulk_discount_path(@merchant1, @discount1))
+
+    expect(page).to have_content("Please fill in all fields")
+  end
+
+  it "throws an error if percentage is over 99" do
+    visit edit_merchant_bulk_discount_path(@merchant1, @discount1)
+
+    fill_in(:quantity, with: 10)
+    fill_in(:percentage, with: 100)
+    click_button("Submit")
+
+    expect(page).to have_content("Percent off must be less than 100")
+  end
+end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -62,24 +62,28 @@ RSpec.describe "Bulk discounts index page" do
     within("#discount-#{@discount1.id}") do
       expect(page).to have_link("Promotion ##{@discount1.id}", href: merchant_bulk_discount_path(@merchant1, @discount1))
       expect(page).to have_content("20% off bulk purchases of 10 or more items")
+      expect(page).to have_link("Edit Promotion ##{@discount1.id}", href: edit_merchant_bulk_discount_path(@merchant1, @discount1))
       expect(page).to have_link("Delete Promotion ##{@discount1.id}")
     end
     
     within("#discount-#{@discount2.id}") do
       expect(page).to have_link("Promotion ##{@discount2.id}", href: merchant_bulk_discount_path(@merchant1, @discount2))
       expect(page).to have_content("15% off bulk purchases of 7 or more items")
+      expect(page).to have_link("Edit Promotion ##{@discount2.id}", href: edit_merchant_bulk_discount_path(@merchant1, @discount2))
       expect(page).to have_link("Delete Promotion ##{@discount2.id}")
     end
     
     within("#discount-#{@discount3.id}") do
       expect(page).to have_link("Promotion ##{@discount3.id}", href: merchant_bulk_discount_path(@merchant1, @discount3))
       expect(page).to have_content("25% off bulk purchases of 15 or more items")
+      expect(page).to have_link("Edit Promotion ##{@discount3.id}", href: edit_merchant_bulk_discount_path(@merchant1, @discount3))
       expect(page).to have_link("Delete Promotion ##{@discount3.id}")
     end
     
     within("#discount-#{@discount4.id}") do
       expect(page).to have_link("Promotion ##{@discount4.id}", href: merchant_bulk_discount_path(@merchant1, @discount4))
       expect(page).to have_content("30% off bulk purchases of 20 or more items")
+      expect(page).to have_link("Edit Promotion ##{@discount4.id}", href: edit_merchant_bulk_discount_path(@merchant1, @discount4))
       expect(page).to have_link("Delete Promotion ##{@discount4.id}")
     end
   end
@@ -87,11 +91,11 @@ RSpec.describe "Bulk discounts index page" do
   #User story 3
   it "can delete discounts" do
     visit merchant_bulk_discounts_path(@merchant1)
-    expect(page).to have_content("Promotion ##{@discount1.id}")
+    expect(page).to have_content("20% off bulk purchases of 10 or more items")
 
     click_link("Delete Promotion ##{@discount1.id}")
 
-    expect(page).to_not have_content("Promotion ##{@discount1.id}")
-
+    expect(page).to have_content("Promotion ##{@discount1.id} Successfully Deleted")
+    expect(page).to_not have_content("20% off bulk purchases of 10 or more items")
   end
 end

--- a/spec/features/dashboard/index_spec.rb
+++ b/spec/features/dashboard/index_spec.rb
@@ -122,6 +122,6 @@ RSpec.describe "merchant dashboard" do
 
   #User story 1
   it "has a link to view all my discounts" do
-    expect(page).to have_link("View My Discounts", href: merchant_bulk_discounts_path(@merchant1))
+    expect(page).to have_link("Bulk Discounts", href: merchant_bulk_discounts_path(@merchant1))
   end
 end


### PR DESCRIPTION
User Story 5
As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated

Other adjustments: Refactor `before_action` methods in bulk discounts controller, add flash alert when discounts are successfully deleted