### PR TITLE
Invoices

### DIFF
--- a/app/models/bulk_discount.rb
+++ b/app/models/bulk_discount.rb
@@ -4,4 +4,5 @@ class BulkDiscount < ApplicationRecord
   validates_numericality_of :quantity
 
   belongs_to :merchant
+  has_many :invoice_items, through: :merchant
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -7,10 +7,49 @@ class Invoice < ApplicationRecord
   has_many :invoice_items
   has_many :items, through: :invoice_items
   has_many :merchants, through: :items
+  has_many :bulk_discounts, through: :merchants
 
   enum status: [:cancelled, :in_progress, :completed]
 
   def total_revenue
     invoice_items.sum("unit_price * quantity")
   end
+
+  def revenue_for(merchant)
+    invoice_items.joins(:item).where('merchant_id = ?', merchant.id).sum('invoice_items.quantity*invoice_items.unit_price')
+  end
+
+  def invoice_items_for(merchant)
+    invoice_items.joins(:item).where('merchant_id = ?', merchant.id)
+  end
+
+  def revenue_with_discounts
+    total_revenue - all_discounts
+  end
+
+  def revenue_with_discounts_for(merchant)
+    
+  end
+
+  def all_discounts
+    Invoice.select("quantity, unit_price, percentage")
+      .from(invoice_items
+        .joins(:bulk_discounts)
+        .select("invoice_items.id, invoice_items.quantity, invoice_items.unit_price, MAX(bulk_discounts.percentage) as percentage")
+        .where("invoice_items.quantity >= bulk_discounts.quantity")
+        .group("invoice_items.id"))
+        .sum("quantity*unit_price*percentage/100")
+  end
 end
+
+# Below is working raw SQL query
+# SELECT SUM(foo.quantity*foo.unit_price*foo.percentage/100) 
+# FROM (SELECT invoice_items.id, invoice_items.quantity, invoice_items.unit_price, MAX(bulk_discounts.percentage) as percentage 
+#       FROM invoice_items INNER JOIN items ON items.id=invoice_items.item_id 
+#       INNER JOIN merchants 
+#       ON merchants.id=items.merchant_id 
+#       INNER JOIN bulk_discounts 
+#       ON bulk_discounts.merchant_id=merchants.id 
+#       WHERE invoice_items.invoice_id=1 
+#       AND (invoice_items.quantity >= bulk_discounts.quantity) 
+#       GROUP BY invoice_items.id) as foo;

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -7,11 +7,17 @@ class InvoiceItem < ApplicationRecord
 
   belongs_to :invoice
   belongs_to :item
+  has_one :merchant, through: :item
+  has_many :bulk_discounts, through: :merchant
 
   enum status: [:pending, :packaged, :shipped]
 
   def self.incomplete_invoices
     invoice_ids = InvoiceItem.where("status = 0 OR status = 1").pluck(:invoice_id)
     Invoice.order(created_at: :asc).find(invoice_ids)
+  end
+
+  def discount
+    bulk_discounts.where('bulk_discounts.quantity <= ?', self.quantity).order('bulk_discounts.percentage desc').first
   end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -14,6 +14,8 @@
       <% end %>
   <p>Created on: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %>
   <p>Total Revenue: <%= number_to_currency(@invoice.total_revenue) %>
+  <p><%= "Final Revenue With Discounts: #{number_to_currency(@invoice.revenue_with_discounts)}" if @invoice.all_discounts != 0 %></p>
+
 
   <h4>Customer:</h4>
     <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %><br>
@@ -29,17 +31,21 @@
         <th class="th1">Quantity</th>
         <th class="th1">Unit Price</th>
         <th class="th1">Status</th>
+        <th class="th1">Discount</th>
       </tr>
     </thead>
 
     <tbody>
       <% @invoice.invoice_items.each do |i| %>
+      <div id="the-status-<%= i.id %>-admin">
         <tr class="tr">
           <td style="text-align:center"><%= i.item.name %></td>
           <td style="text-align:center"><%= i.quantity %></td>
           <td style="text-align:center"><%= number_to_currency(i.unit_price) %></td>
           <td style="text-align:center"><%= i.status%></td>
+          <td style="text-align:center"><%= "#{i.discount.percentage}% Off" if i.discount %></td>
         </tr>
+      </div>
       <% end %>
     </tbody>
   </table>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -42,7 +42,7 @@
               <%= form_with model: @invoice, url: merchant_invoice_path(@merchant, @invoice), method: :patch, local: true do |f| %>
                 <%= f.select :status, Invoice.statuses.keys, selected: "#{@invoice.status}" %>
                 <%= f.submit 'Update Invoice' %>
-            <td style="text-align:center"><%= "#{i.discount.percentage}% off" if i.discount %></td>
+            <td style="text-align:center"><%= link_to "#{i.discount.percentage}% Off", merchant_bulk_discount_path(@merchant, i.discount)  if i.discount %></td>
               <% end %>
               </td>
           </tr>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -26,6 +26,7 @@
         <th class="th1">Quantity</th>
         <th class="th1">Unit Price</th>
         <th class="th1">Status</th>
+        <th class="th1">Bulk Discounts Applied</th>
       </tr>
     </thead>
 
@@ -40,6 +41,7 @@
               <%= form_with model: @invoice, url: merchant_invoice_path(@merchant, @invoice), method: :patch, local: true do |f| %>
                 <%= f.select :status, Invoice.statuses.keys, selected: "#{@invoice.status}" %>
                 <%= f.submit 'Update Invoice' %>
+            <td style="text-align:center"><%= "#{i.discount.percentage}% off" if i.discount %></td>
               <% end %>
               </td>
           </tr>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -11,7 +11,8 @@
   <br>
 
   <p> Created on: <%= @invoice.created_at.strftime("%A, %B %-d, %Y") %></p>
-  <p>Total Revenue: <%= @invoice.total_revenue %></p>
+  <p>Total Revenue: <%= @invoice.revenue_for(@merchant) %></p>
+  <p><%= "Final Revenue With Discounts: #{@invoice.revenue_with_discounts_for(@merchant)}" if @invoice.discounts_for(@merchant) != 0 %></p>
 
 
   <h4>Customer:</h4>
@@ -31,7 +32,7 @@
     </thead>
 
     <tbody>
-      <% @invoice.invoice_items.each do |i| %>
+      <% @invoice.invoice_items_for(@merchant).each do |i| %>
         <section id="the-status-<%= i.id %>">
           <tr class="tr">
             <td style="text-align:center"><%= i.item.name %></td>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe "Admin Invoices Index Page" do
   before :each do
     @m1 = Merchant.create!(name: "Merchant 1")
+    @m2 = Merchant.create!(name: "Merchant 2")
 
     @c1 = Customer.create!(first_name: "Yo", last_name: "Yoz", address: "123 Heyyo", city: "Whoville", state: "CO", zip: 12345)
     @c2 = Customer.create!(first_name: "Hey", last_name: "Heyz")
@@ -12,10 +13,12 @@ describe "Admin Invoices Index Page" do
 
     @item_1 = Item.create!(name: "test", description: "lalala", unit_price: 6, merchant_id: @m1.id)
     @item_2 = Item.create!(name: "rest", description: "dont test me", unit_price: 12, merchant_id: @m1.id)
+    @item_3 = Item.create!(name: "another", description: "here we go again", unit_price: 15, merchant_id: @m2.id)
 
     @ii_1 = InvoiceItem.create!(invoice_id: @i1.id, item_id: @item_1.id, quantity: 12, unit_price: 2, status: 0)
-    @ii_2 = InvoiceItem.create!(invoice_id: @i1.id, item_id: @item_2.id, quantity: 6, unit_price: 1, status: 1)
+    @ii_2 = InvoiceItem.create!(invoice_id: @i1.id, item_id: @item_2.id, quantity: 15, unit_price: 1, status: 1)
     @ii_3 = InvoiceItem.create!(invoice_id: @i2.id, item_id: @item_2.id, quantity: 87, unit_price: 12, status: 2)
+    @ii_4 = InvoiceItem.create!(invoice_id: @i1.id, item_id: @item_3.id, quantity: 30, unit_price: 20, status: 1)
 
     visit admin_invoice_path(@i1)
   end
@@ -38,25 +41,23 @@ describe "Admin Invoices Index Page" do
   it "should display all the items on the invoice" do
     expect(page).to have_content(@item_1.name)
     expect(page).to have_content(@item_2.name)
+    expect(page).to have_content(@item_3.name)
 
     expect(page).to have_content(@ii_1.quantity)
     expect(page).to have_content(@ii_2.quantity)
+    expect(page).to have_content(@ii_4.quantity)
 
     expect(page).to have_content("$#{@ii_1.unit_price}")
     expect(page).to have_content("$#{@ii_2.unit_price}")
+    expect(page).to have_content("$#{@ii_4.unit_price}")
 
     expect(page).to have_content(@ii_1.status)
     expect(page).to have_content(@ii_2.status)
+    expect(page).to have_content(@ii_4.status)
 
     expect(page).to_not have_content(@ii_3.quantity)
     expect(page).to_not have_content("$#{@ii_3.unit_price}")
     expect(page).to_not have_content(@ii_3.status)
-  end
-
-  it "should display the total revenue the invoice will generate" do
-    expect(page).to have_content("Total Revenue: $#{@i1.total_revenue}")
-
-    expect(page).to_not have_content(@i2.total_revenue)
   end
 
   it "should have status as a select field that updates the invoices status" do
@@ -70,35 +71,69 @@ describe "Admin Invoices Index Page" do
     end
   end
 
-  xit "discounts are specific to merchant" do
-    merchantA = Merchant.create!(name: "Queen Soopers")
-    merchantB = Merchant.create!(name: "Someone Else")
-    discountA = merchantA.bulk_discounts.create!(percentage: 20, quantity: 10, merchant: merchantA)
-    discountB = merchantA.bulk_discounts.create!(percentage: 30, quantity: 15, merchant: merchantA)
-    itemA = merchantA.items.create!(name: 'Cheese', description: 'Cheddar goodness', unit_price: 1000, merchant: merchantA)
-    itemB = merchantA.items.create!(name: 'CousCous', description: 'yummy', unit_price: 2000, merchant: merchantA)
-    itemC = merchantB.items.create!(name: 'Thing', description: 'just a thing', unit_price: 3000, merchant: merchantB)
-    customer = Customer.create!(first_name: 'Bilbo', last_name: 'Baggins')
+  #User story 8
+  it "should display the (non-discounted) total revenue the invoice will generate" do
+    expect(page).to have_content("Total Revenue: $#{@i1.total_revenue}")
 
-    invoiceA = Invoice.create!(customer: customer, status: 2)
-    invoice_item1 = InvoiceItem.create!(invoice: invoiceA, item: itemA, quantity: 12, unit_price: 1000, status: 1)
-    invoice_item2 = InvoiceItem.create!(invoice: invoiceA, item: itemB, quantity: 15, unit_price: 2000, status: 1)
-    invoice_item3 = InvoiceItem.create!(invoice: invoiceA, item: itemC, quantity: 15, unit_price: 3000, status: 1)
+    expect(page).to_not have_content(@i2.total_revenue)
+  end
 
-    visit admin_invoice_path(invoiceA)
+  it "should display total revenue after discounts" do
+    expect(@i1.revenue_with_discounts).to eq(@i1.total_revenue)
+    expect(page).to_not have_content("Final Revenue With Discounts:")
+    
+    BulkDiscount.create!(percentage: 40, quantity: 20, merchant: @m1)
+    visit admin_invoice_path(@i1)
 
-    within("#invoice_item_#{invoice_item1.id}") do
+    expect(@i1.revenue_with_discounts).to eq(@i1.total_revenue)
+    expect(page).to_not have_content("Final Revenue With Discounts:")
+
+    BulkDiscount.create!(percentage: 30, quantity: 15, merchant: @m1)
+    visit admin_invoice_path(@i1)
+
+    expect(@i1.total_revenue).to eq(639)
+    expect(@i1.revenue_with_discounts).to eq(634.5)
+    expect(page).to have_content("Final Revenue With Discounts: $634.50")
+
+    BulkDiscount.create!(percentage: 20, quantity: 10, merchant: @m1)
+    visit admin_invoice_path(@i1)
+
+    expect(@i1.total_revenue).to eq(639)
+    expect(@i1.revenue_with_discounts).to eq(629.7)
+    expect(page).to have_content("Final Revenue With Discounts: $629.70")
+
+    BulkDiscount.create!(percentage: 20, quantity: 10, merchant: @m2)
+    visit admin_invoice_path(@i1)
+
+    expect(@i1.total_revenue).to eq(639)
+    expect(@i1.revenue_with_discounts).to eq(509.7)
+    expect(page).to have_content("Final Revenue With Discounts: $509.70")
+  end
+
+  it "shows discounts for each item, where applicable" do
+    visit admin_invoice_path(@i1)
+
+    expect(page).to_not have_content("20% Off")
+    expect(page).to_not have_content("30% Off")
+    discount1 = BulkDiscount.create!(percentage: 30, quantity: 15, merchant: @m1)
+    discount2 = BulkDiscount.create!(percentage: 20, quantity: 10, merchant: @m1)
+    discount3 = BulkDiscount.create!(percentage: 20, quantity: 10, merchant: @m2)
+
+    visit admin_invoice_path(@i1)
+
+    expect(@ii_1.discount).to eq(discount2)
+    within("#the-status-#{@ii_1.id}-admin") do
       expect(page).to have_content("20% Off")
     end
-
-    within("#invoice_item_#{invoice_item2.id}") do
+    
+    expect(@ii_2.discount).to eq(discount1)
+    within("#the-status-#{@ii_2.id}-admin") do
       expect(page).to have_content("30% Off")
     end
 
-    within("#invoice_item-#{invoice_item3.id}") do
-      expect(page).to_not have_content("Off")
+    expect(@ii_4.discount).to eq(discount3)
+    within("#the-status-#{@ii_4.id}-admin") do
+      expect(page).to have_content("20% Off")
     end
-
-    expect(page).to have_content("total revenue")
   end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -69,4 +69,36 @@ describe "Admin Invoices Index Page" do
       expect(@i1.status).to eq("completed")
     end
   end
+
+  xit "discounts are specific to merchant" do
+    merchantA = Merchant.create!(name: "Queen Soopers")
+    merchantB = Merchant.create!(name: "Someone Else")
+    discountA = merchantA.bulk_discounts.create!(percentage: 20, quantity: 10, merchant: merchantA)
+    discountB = merchantA.bulk_discounts.create!(percentage: 30, quantity: 15, merchant: merchantA)
+    itemA = merchantA.items.create!(name: 'Cheese', description: 'Cheddar goodness', unit_price: 1000, merchant: merchantA)
+    itemB = merchantA.items.create!(name: 'CousCous', description: 'yummy', unit_price: 2000, merchant: merchantA)
+    itemC = merchantB.items.create!(name: 'Thing', description: 'just a thing', unit_price: 3000, merchant: merchantB)
+    customer = Customer.create!(first_name: 'Bilbo', last_name: 'Baggins')
+
+    invoiceA = Invoice.create!(customer: customer, status: 2)
+    invoice_item1 = InvoiceItem.create!(invoice: invoiceA, item: itemA, quantity: 12, unit_price: 1000, status: 1)
+    invoice_item2 = InvoiceItem.create!(invoice: invoiceA, item: itemB, quantity: 15, unit_price: 2000, status: 1)
+    invoice_item3 = InvoiceItem.create!(invoice: invoiceA, item: itemC, quantity: 15, unit_price: 3000, status: 1)
+
+    visit admin_invoice_path(invoiceA)
+
+    within("#invoice_item_#{invoice_item1.id}") do
+      expect(page).to have_content("20% Off")
+    end
+
+    within("#invoice_item_#{invoice_item2.id}") do
+      expect(page).to have_content("30% Off")
+    end
+
+    within("#invoice_item-#{invoice_item3.id}") do
+      expect(page).to_not have_content("Off")
+    end
+
+    expect(page).to have_content("total revenue")
+  end
 end

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -17,40 +17,41 @@ RSpec.describe "invoices show" do
 
     @customer_1 = Customer.create!(first_name: "Joey", last_name: "Smith")
     @customer_2 = Customer.create!(first_name: "Cecilia", last_name: "Jones")
-    @customer_3 = Customer.create!(first_name: "Mariah", last_name: "Carrey")
-    @customer_4 = Customer.create!(first_name: "Leigh Ann", last_name: "Bron")
-    @customer_5 = Customer.create!(first_name: "Sylvester", last_name: "Nader")
-    @customer_6 = Customer.create!(first_name: "Herber", last_name: "Kuhn")
+    # @customer_3 = Customer.create!(first_name: "Mariah", last_name: "Carrey")
+    # @customer_4 = Customer.create!(first_name: "Leigh Ann", last_name: "Bron")
+    # @customer_5 = Customer.create!(first_name: "Sylvester", last_name: "Nader")
+    # @customer_6 = Customer.create!(first_name: "Herber", last_name: "Kuhn")
 
     @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-27 14:54:09")
-    @invoice_2 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-28 14:54:09")
-    @invoice_3 = Invoice.create!(customer_id: @customer_2.id, status: 2)
-    @invoice_4 = Invoice.create!(customer_id: @customer_3.id, status: 2)
-    @invoice_5 = Invoice.create!(customer_id: @customer_4.id, status: 2)
-    @invoice_6 = Invoice.create!(customer_id: @customer_5.id, status: 2)
-    @invoice_7 = Invoice.create!(customer_id: @customer_6.id, status: 2)
+    # @invoice_2 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-28 14:54:09")
+    # @invoice_3 = Invoice.create!(customer_id: @customer_2.id, status: 2)
+    # @invoice_4 = Invoice.create!(customer_id: @customer_3.id, status: 2)
+    # @invoice_5 = Invoice.create!(customer_id: @customer_4.id, status: 2)
+    # @invoice_6 = Invoice.create!(customer_id: @customer_5.id, status: 2)
+    # @invoice_7 = Invoice.create!(customer_id: @customer_6.id, status: 2)
 
-    @invoice_8 = Invoice.create!(customer_id: @customer_6.id, status: 1)
+    # @invoice_8 = Invoice.create!(customer_id: @customer_6.id, status: 1)
 
     @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
-    @ii_2 = InvoiceItem.create!(invoice_id: @invoice_2.id, item_id: @item_1.id, quantity: 1, unit_price: 10, status: 2)
-    @ii_3 = InvoiceItem.create!(invoice_id: @invoice_3.id, item_id: @item_2.id, quantity: 2, unit_price: 8, status: 2)
-    @ii_4 = InvoiceItem.create!(invoice_id: @invoice_4.id, item_id: @item_3.id, quantity: 3, unit_price: 5, status: 1)
-    @ii_6 = InvoiceItem.create!(invoice_id: @invoice_5.id, item_id: @item_4.id, quantity: 1, unit_price: 1, status: 1)
-    @ii_7 = InvoiceItem.create!(invoice_id: @invoice_6.id, item_id: @item_7.id, quantity: 1, unit_price: 3, status: 1)
-    @ii_8 = InvoiceItem.create!(invoice_id: @invoice_7.id, item_id: @item_8.id, quantity: 1, unit_price: 5, status: 1)
-    @ii_9 = InvoiceItem.create!(invoice_id: @invoice_7.id, item_id: @item_4.id, quantity: 1, unit_price: 1, status: 1)
-    @ii_10 = InvoiceItem.create!(invoice_id: @invoice_8.id, item_id: @item_5.id, quantity: 1, unit_price: 1, status: 1)
+    # @ii_2 = InvoiceItem.create!(invoice_id: @invoice_2.id, item_id: @item_1.id, quantity: 1, unit_price: 10, status: 2)
+    # @ii_3 = InvoiceItem.create!(invoice_id: @invoice_3.id, item_id: @item_2.id, quantity: 2, unit_price: 8, status: 2)
+    # @ii_4 = InvoiceItem.create!(invoice_id: @invoice_4.id, item_id: @item_3.id, quantity: 3, unit_price: 5, status: 1)
+    # @ii_6 = InvoiceItem.create!(invoice_id: @invoice_5.id, item_id: @item_4.id, quantity: 1, unit_price: 1, status: 1)
+    # @ii_7 = InvoiceItem.create!(invoice_id: @invoice_6.id, item_id: @item_7.id, quantity: 1, unit_price: 3, status: 1)
+    # @ii_8 = InvoiceItem.create!(invoice_id: @invoice_7.id, item_id: @item_8.id, quantity: 1, unit_price: 5, status: 1)
+    # @ii_9 = InvoiceItem.create!(invoice_id: @invoice_7.id, item_id: @item_4.id, quantity: 1, unit_price: 1, status: 1)
+    # @ii_10 = InvoiceItem.create!(invoice_id: @invoice_8.id, item_id: @item_5.id, quantity: 1, unit_price: 1, status: 1)
     @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 12, unit_price: 6, status: 1)
+    @ii_12 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_5.id, quantity: 15, unit_price: 10, status: 1)
 
     @transaction1 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_1.id)
-    @transaction2 = Transaction.create!(credit_card_number: 230948, result: 1, invoice_id: @invoice_2.id)
-    @transaction3 = Transaction.create!(credit_card_number: 234092, result: 1, invoice_id: @invoice_3.id)
-    @transaction4 = Transaction.create!(credit_card_number: 230429, result: 1, invoice_id: @invoice_4.id)
-    @transaction5 = Transaction.create!(credit_card_number: 102938, result: 1, invoice_id: @invoice_5.id)
-    @transaction6 = Transaction.create!(credit_card_number: 879799, result: 0, invoice_id: @invoice_6.id)
-    @transaction7 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_7.id)
-    @transaction8 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_8.id)
+    # @transaction2 = Transaction.create!(credit_card_number: 230948, result: 1, invoice_id: @invoice_2.id)
+    # @transaction3 = Transaction.create!(credit_card_number: 234092, result: 1, invoice_id: @invoice_3.id)
+    # @transaction4 = Transaction.create!(credit_card_number: 230429, result: 1, invoice_id: @invoice_4.id)
+    # @transaction5 = Transaction.create!(credit_card_number: 102938, result: 1, invoice_id: @invoice_5.id)
+    # @transaction6 = Transaction.create!(credit_card_number: 879799, result: 0, invoice_id: @invoice_6.id)
+    # @transaction7 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_7.id)
+    # @transaction8 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_8.id)
   end
 
   it "shows the invoice information" do
@@ -69,14 +70,18 @@ RSpec.describe "invoices show" do
     expect(page).to_not have_content(@customer_2.last_name)
   end
 
-  it "shows the item information" do
+  it "shows the item information belonging to that merchant" do
     visit merchant_invoice_path(@merchant1, @invoice_1)
 
+    expect(@invoice_1.items).to eq([@item_1, @item_8, @item_5])
+    # Only 1 and 8 belong to @merchant1
     expect(page).to have_content(@item_1.name)
     expect(page).to have_content(@ii_1.quantity)
     expect(page).to have_content(@ii_1.unit_price)
-    expect(page).to_not have_content(@ii_4.unit_price)
-
+    expect(page).to have_content(@item_8.name)
+    expect(page).to have_content(@ii_11.quantity)
+    expect(page).to have_content(@ii_11.unit_price)
+    expect(page).to_not have_content(@item_5.name)
   end
 
   it "shows a select field to update the invoice status" do
@@ -94,27 +99,26 @@ RSpec.describe "invoices show" do
     end
   end
 
-  xit "only shows items for this merchant" do
-    InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_5.id, quantity: 12, unit_price: 6, status: 1)
+  it "only shows items for this merchant" do
     visit merchant_invoice_path(@merchant1, @invoice_1)
 
-    expect(page).to have_content("something") #placeholder
-    expect(page).to_not have_content("another thing") #placeholder
+    expect(@invoice_1.invoice_items).to eq([@ii_1, @ii_11, @ii_12])
+    expect(page).to have_content(@item_1.name)
+    expect(page).to have_content(@item_8.name)
+    expect(page).to_not have_content(@item_5.name)
   end
   
-  # User story 6 
+  # User story 6
   it "shows the total (non-discounted) revenue for this invoice for this merchant" do
-    InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_5.id, quantity: 12, unit_price: 6, status: 1)
     visit merchant_invoice_path(@merchant1, @invoice_1)
 
-    expect(@invoice_1.total_revenue).to eq(250)
+    expect(@invoice_1.total_revenue).to eq(312)
     expect(@invoice_1.revenue_for(@merchant1)).to eq(162.0)
-    expect(page).to have_content("Total Revenue: 162.0")
-    expect(page).to_not have_content("250")
-    #check for unit testing
+    expect(page).to have_content(@invoice_1.revenue_for(@merchant1))
+    expect(page).to_not have_content(@invoice_1.total_revenue)
   end
 
-  xit "shows final discounted revenue for this invoice for this merchant" do
+  it "shows final discounted revenue for this invoice for this merchant" do
     visit merchant_invoice_path(@merchant1, @invoice_1)
 
     expect(page).to have_content("Total Revenue: 162.0")
@@ -125,14 +129,29 @@ RSpec.describe "invoices show" do
     visit merchant_invoice_path(@merchant1, @invoice_1)
 
     expect(page).to have_content("Total Revenue: 162")
-    expect(page).to have_content("Final Revenue With Discounts: #{@invoice_1.revenue_with_discounts_for(@merchant1)}")
+    expect(@invoice_1.discounts_for(@merchant1)).to eq(14.4)
+    expect(@invoice_1.revenue_with_discounts_for(@merchant1)).to eq(147.6)
+    expect(page).to have_content("Final Revenue With Discounts: 147.6")
   end
-  #   6: Merchant Invoice Show Page: Total Revenue and Discounted Revenue
 
-# As a merchant
-# When I visit my merchant invoice show page
-# Then I see the total revenue for my merchant from this invoice (not including discounts)
-# And I see the total discounted revenue for my merchant from this invoice which includes bulk discounts in the calculation
+  # User story 7
+  xit "shows discounts for each item, where applicable" do
+    visit merchant_invoice_path(@merchant1, @invoice_1)
+
+    expect(page).to_not have_link("20% Off")
+
+    discount = BulkDiscount.create!(percentage: 20, quantity: 10, merchant: @merchant1)
+
+    visit merchant_invoice_path(@merchant1, @invoice_1)
+
+    within("#the-status-#{@ii_11.id}") do
+      expect(page).to have_link("20% off", href: merchant_bulk_discount_path(@merchant1, discount))
+    end
+
+    within("#the-status-#{@ii_1.id}") do
+      expect(page).to_not have_content("% Off")
+    end
+  end
 
   xit "discounts count by same item, and aren't cumulative to all items" do
     merchantA = Merchant.create!(name: "Queen Soopers")
@@ -147,7 +166,7 @@ RSpec.describe "invoices show" do
 
     visit merchant_invoice_path(mechantA, invoiceA)
     expect(page).to_not have_content("20% off")
-    expect(page).to_not have_content("whatever the discount total is")
+    # expect(page).to_not have_content("whatever the discount total is")
 
     invoice_item1.update(quantity: 10)
     visit merchant_invoice_path(mechantA, invoiceA)
@@ -227,22 +246,5 @@ RSpec.describe "invoices show" do
     expect(invoice_item1.discount).to eq(discountA)
     expect(invoice_item2.discount).to eq(discountB)
     expect(invoice_item3.discount).to eq(nil)
-  end
-
-  # User story 7
-  xit "shows discounts for each item, where applicable" do
-    visit merchant_invoice_path(@merchant1, @invoice_1)
-
-    within("#the-status-#{@ii_11.id}") do
-      expect(page).to_not have_link("20% off")
-    end
-
-    discount = BulkDiscount.create!(percentage: 20, quantity: 10, merchant: @merchant1)
-
-    visit merchant_invoice_path(@merchant1, @invoice_1)
-
-    within("#the-status-#{@ii_11.id}") do
-      expect(page).to have_link("20% off", href: merchant_bulk_discount_path(@merchant1, discount))
-    end
   end
 end

--- a/spec/models/bulk_discount_spec.rb
+++ b/spec/models/bulk_discount_spec.rb
@@ -10,22 +10,7 @@ RSpec.describe BulkDiscount do
 
   describe "relationships" do
     it {should belong_to :merchant}
+    it {should have_many :invoice_items }
   end
-
-  # it "kicks in when enough items are ordered" do
-  #   # need one merchant, one item, one bulk discount, one invoice, n - 1 invoice items
-  #   # check that unit_price on invoice_items matches unit_price on items 
-  #   # add one more invoice_items
-  #   # check that price in invoice_items is now discounted
-  # end
-
-  # it "is eligible for all items a merchant sells" do
-  #   # need one merchant, two items, one bulk discount, one invoice, n-1 invoice_items per item
-  #   # check that each item's unit_price is same as item unit_price
-  #   # add one more invoice_item for first item
-  #   # check that first item has been discounted, but second has not
-  #   # add another invoice_item for second item
-  #   # check both are discounted
-  # end
 
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Invoice, type: :model do
     it { should have_many(:merchants).through(:items) }
     it { should have_many :transactions}
   end
+
   describe "instance methods" do
     it "total_revenue" do
       @merchant1 = Merchant.create!(name: 'Hair Care')
@@ -22,6 +23,123 @@ RSpec.describe Invoice, type: :model do
       @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 1, unit_price: 10, status: 1)
 
       expect(@invoice_1.total_revenue).to eq(100)
+    end
+
+    xit "can filter invoice items by merchant" do      
+      expect(@invoice1.invoice_items_for(@merchant1)).to eq([@invoice_item1])
+    end
+  
+    xit "can filter total_revenue by merchant" do
+      expect(@invoice1.revenue_for(@merchant1)).to eq(68175)
+    end
+
+    it "all_discounts" do
+      @merchant1 = Merchant.create!(name: 'Hair Care')
+      @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
+      @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+      @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
+      @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-27 14:54:09")
+      @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 10, unit_price: 10, status: 2)
+      @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 15, unit_price: 10, status: 1)
+
+      expect(@invoice_1.total_revenue).to eq(250)
+      expect(@invoice_1.all_discounts).to eq(0)
+      BulkDiscount.create!(percentage: 40, quantity: 20, merchant: @merchant1)
+      expect(@invoice_1.total_revenue).to eq(250)
+      expect(@invoice_1.all_discounts).to eq(0)
+      BulkDiscount.create!(percentage: 30, quantity: 15, merchant: @merchant1)
+      expect(@invoice_1.total_revenue).to eq(250)
+      expect(@invoice_1.all_discounts).to eq(45)
+
+      BulkDiscount.create!(percentage: 20, quantity: 10, merchant: @merchant1)
+      
+      expect(@invoice_1.total_revenue).to eq(250)
+      expect(@invoice_1.all_discounts).to eq(65)
+    end
+
+    it "revenue_with_discounts" do
+      @merchant1 = Merchant.create!(name: 'Hair Care')
+      @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
+      @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+      @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
+      @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-27 14:54:09")
+      @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 10, unit_price: 10, status: 2)
+      @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 15, unit_price: 10, status: 1)
+
+      expect(@invoice_1.total_revenue).to eq(250)
+      expect(@invoice_1.revenue_with_discounts).to eq(250)
+      BulkDiscount.create!(percentage: 40, quantity: 20, merchant: @merchant1)
+      expect(@invoice_1.total_revenue).to eq(250)
+      expect(@invoice_1.revenue_with_discounts).to eq(250)
+
+      BulkDiscount.create!(percentage: 30, quantity: 15, merchant: @merchant1)
+      expect(@invoice_1.total_revenue).to eq(250)
+      expect(@invoice_1.revenue_with_discounts).to eq(205)
+      BulkDiscount.create!(percentage: 20, quantity: 10, merchant: @merchant1)
+      
+      expect(@invoice_1.total_revenue).to eq(250)
+      expect(@invoice_1.revenue_with_discounts).to eq(185)
+    end
+
+    xit "discounts count by same item, and aren't cumulative to all items" do
+      merchantA = Merchant.create!(name: "Queen Soopers")
+      discountA = merchantA.bulk_discounts.create!(percentage: 20, quantity: 10, merchant: merchantA)
+      itemA = merchantA.items.create!(name: 'Cheese', description: 'Cheddar goodness', unit_price: 1000, merchant: merchantA)
+      itemB = merchantA.items.create!(name: 'CousCous', description: 'yummy', unit_price: 2000, merchant: merchantA)
+      customer = Customer.create!(first_name: 'Bilbo', last_name: 'Baggins')
+
+      invoiceA = Invoice.create!(customer: customer, status: 2)
+      invoice_item1 = InvoiceItem.create!(invoice: invoiceA, item: itemA, quantity: 5, unit_price: 1000, status: 1)
+      invoice_item2 = InvoiceItem.create!(invoice: invoiceA, item: itemB, quantity: 5, unit_price: 1000, status: 1)
+
+      expect(invoice_item1.discount).to eq(nil) 
+      expect(invoice_item2.discount).to eq(nil) 
+
+      invoice_item1.update(quantity: 10)
+
+      expect(invoice_item1.discount).to eq(discountA)
+      expect(invoice_item2.discount).to eq(nil)
+    end
+
+    xit "discounts by greatest applicable discount" do
+      merchantA = Merchant.create!(name: "Queen Soopers")
+      discountA = merchantA.bulk_discounts.create!(percentage: 20, quantity: 10, merchant: merchantA)
+      discountB = merchantA.bulk_discounts.create!(percentage: 30, quantity: 15, merchant: merchantA)
+      itemA = merchantA.items.create!(name: 'Cheese', description: 'Cheddar goodness', unit_price: 1000, merchant: merchantA)
+      itemB = merchantA.items.create!(name: 'CousCous', description: 'yummy', unit_price: 2000, merchant: merchantA)
+      customer = Customer.create!(first_name: 'Bilbo', last_name: 'Baggins')
+
+      invoiceA = Invoice.create!(customer: customer, status: 2)
+      invoice_item1 = InvoiceItem.create!(invoice: invoiceA, item: itemA, quantity: 12, unit_price: 1000, status: 1)
+      invoice_item2 = InvoiceItem.create!(invoice: invoiceA, item: itemB, quantity: 15, unit_price: 1000, status: 1)
+
+      expect(invoice_item1.discount).to eq(discountA)
+      expect(invoice_item2.discount).to eq(discountB)
+
+      discountB.update(percentage: 15)
+
+      expect(invoice_item1.discount).to eq(discountA)
+      expect(invoice_item2.discount).to eq(discountA)
+    end
+
+    xit "discounts by specific merchant" do
+      merchantA = Merchant.create!(name: "Queen Soopers")
+      merchantB = Merchant.create!(name: "Someone Else")
+      discountA = merchantA.bulk_discounts.create!(percentage: 20, quantity: 10, merchant: merchantA)
+      discountB = merchantA.bulk_discounts.create!(percentage: 30, quantity: 15, merchant: merchantA)
+      itemA = merchantA.items.create!(name: 'Cheese', description: 'Cheddar goodness', unit_price: 1000, merchant: merchantA)
+      itemB = merchantA.items.create!(name: 'CousCous', description: 'yummy', unit_price: 2000, merchant: merchantA)
+      itemC = merchantB.items.create!(name: 'Thing', description: 'just a thing', unit_price: 3000, merchant: merchantB)
+      customer = Customer.create!(first_name: 'Bilbo', last_name: 'Baggins')
+
+      invoiceA = Invoice.create!(customer: customer, status: 2)
+      invoice_item1 = InvoiceItem.create!(invoice: invoiceA, item: itemA, quantity: 12, unit_price: 1000, status: 1)
+      invoice_item2 = InvoiceItem.create!(invoice: invoiceA, item: itemB, quantity: 15, unit_price: 2000, status: 1)
+      invoice_item3 = InvoiceItem.create!(invoice: invoiceA, item: itemC, quantity: 15, unit_price: 3000, status: 1)
+
+      expect(invoice_item1.discount).to eq(discountA)
+      expect(invoice_item2.discount).to eq(discountB)
+      expect(invoice_item3.discount).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
User stories 6, 7, and 8 

Methods in the starter repo did not account for only one merchant's information being shown on a merchant's invoice show page. Methods such as `revenue_for(merchant)` and `invoice_items_for(merchant)` were copied (along with their tests) from the group project. Tests and views from the starter were updated appropriately.

Added two new query methods that calculate discounts as applied to an entire invoice, and as applied to just one merchant whose items are on that invoice. Final discounted revenue was then calculated with other methods that subtracted discounts from total.

Query method added to return the exact discount applicable to a specific invoice_item, so it can be included on the view page in a new Discount column in the items table.